### PR TITLE
compose.yml: don't run as privileged

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,6 @@ services:
     build: .
     read_only: true
     restart: on-failure:10
-    privileged: true
     environment:
       - LOG_LEVEL=INFO # INFO is the default
       - PYTHONUNBUFFERED=1


### PR DESCRIPTION
This should not be necessary any more since the change to pyzeroconf from D-Bus/Avahi